### PR TITLE
repl_full-en_punctuationが正しく全体に対してを置換するように修正

### DIFF
--- a/lib.typ
+++ b/lib.typ
@@ -35,9 +35,11 @@
 }
 
 // 全角コンマ等への変更
-#let repl_full-en_punctuation() = {
+#let repl_full-en_punctuation(body) = {
   show "、": "，"
   show "。": "．"
+
+  body
 }
 
 #let report() = {}


### PR DESCRIPTION
let repl_full-en_punctuation関数の引数にbodyがなく、正しく機能していなかったので引数を追加しました。